### PR TITLE
fix iconv -o compatibility

### DIFF
--- a/115-strm.sh
+++ b/115-strm.sh
@@ -785,11 +785,11 @@ create_strm_files()
 echo \"strm文件已更新。\"
 "
 
-            script_name="updata-115-strm.sh"
+            script_name="update-115-strm.sh"
             echo "$script_content" > "$script_dir/$script_name"
 
             chmod +x "$script_dir/$script_name"
-            echo "自动更新脚本updata-115-strm已生成，请添加到任务计划，可配置定时执行，在执行前，记得先到115生成目录树。"
+            echo "自动更新脚本update-115-strm已生成，请添加到任务计划，可配置定时执行，在执行前，记得先到115生成目录树。"
             ;;
         2)
             echo "功能待实现。"

--- a/115-strm.sh
+++ b/115-strm.sh
@@ -119,7 +119,7 @@ convert_directory_tree() {
 
     # 转换目录树文件为 UTF-8 格式，以便处理（如有需要）
     converted_file="$directory_tree_dir/$directory_tree_base.converted"
-    iconv -f utf-16le -t utf-8 "$directory_tree_file" -o "$converted_file"
+    iconv -f utf-16le -t utf-8 "$directory_tree_file" > "$converted_file"
 
     # 生成的目录文件路径
     generated_directory_file="${converted_file}_目录文件.txt"


### PR DESCRIPTION
```bash
iconv -f UTF-16LE -t UTF-8 目录树.txt  -o 目录树.txt.converted
```
-o 选项并不是标准的参数，这导致了报错。标准 iconv 的输出应该通过重定向或者直接输出到标准输出

```bash
iconv -f UTF-16LE -t UTF-8 目录树.txt > 目录树.txt.converted
```